### PR TITLE
Add HTTP methods as route handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Example:
 import restx.App;
 
 class Main implements restx.IRoute {
-  @:path("/")
+  @:get("/")
   function index()
     response.send("Hello World!");
 
@@ -20,3 +20,5 @@ class Main implements restx.IRoute {
   }
 }
 ```
+
+Using `@:get("/path")` will set the following function to handle GET requests on the `/path` route. In addition to `get`, you can create handlers for `post`, `put`, and `delete` requests, as well as [a variety of other HTTP methods](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html).

--- a/src/restx/Method.hx
+++ b/src/restx/Method.hx
@@ -1,0 +1,12 @@
+package restx;
+
+@:enum abstract Method(String) from String to String {
+  var Get = "get";
+  var Post = "post";
+  var Head = "head";
+  var Options = "options";
+  var Put = "put";
+  var Delete = "delete";
+  var Trace = "trace";
+  var Connect = "connect";
+}

--- a/src/restx/Methods.hx
+++ b/src/restx/Methods.hx
@@ -1,0 +1,5 @@
+package restx;
+
+class Methods {
+  public static var list(default, never) : Iterable<Method> = [Get, Post, Head, Options, Put, Delete, Trace, Connect];
+}

--- a/src/restx/RouteProcess.hx
+++ b/src/restx/RouteProcess.hx
@@ -9,14 +9,14 @@ import restx.core.ArgumentProcessor;
 class RouteProcess<TRoute : IRoute, TArgs : {}> {
   var instance : TRoute;
   var argumentProcessor : ArgumentProcessor<TArgs>;
-  var arguments : TArgs;
+  var args : TArgs;
   public function new(instance : TRoute, argumentProcessor : ArgumentProcessor<TArgs>) {
     this.instance = instance;
     this.argumentProcessor = argumentProcessor;
   }
 
   public function run(req : Request, res : Response, next : Next) {
-    argumentProcessor.processArguments(req, arguments).then(function(result) {
+    argumentProcessor.processArguments(req, args).then(function(result) {
       switch result {
         case Ok:
           instance.request = req;

--- a/src/restx/Router.hx
+++ b/src/restx/Router.hx
@@ -1,10 +1,10 @@
 package restx;
+import restx.Method;
 
 #if macro
 import haxe.macro.Expr;
 #else
 import haxe.Constraints.Function;
-import js.node.http.Method;
 #end
 
 class Router {

--- a/src/restx/core/DynamicRouteProcess.hx
+++ b/src/restx/core/DynamicRouteProcess.hx
@@ -8,13 +8,13 @@ class DynamicRouteProcess extends RouteProcess<IRoute, {}> {
   public function new(instance : IRoute, method : Function, argumentProcessor : ArgumentProcessor<{}>) {
     super(instance, argumentProcessor);
     this.method = method;
-    this.arguments = {};
+    this.args = {};
   }
 
   override function execute() {
-    var list = Reflect.fields(arguments);
+    var list = Reflect.fields(args);
     Reflect.callMethod(null, method, list.map(function(arg) {
-      return Reflect.field(arguments, arg);
+      return Reflect.field(args, arg);
     }));
   }
 }

--- a/src/restx/core/macros/AutoRegisterRoute.hx
+++ b/src/restx/core/macros/AutoRegisterRoute.hx
@@ -5,6 +5,7 @@ import haxe.macro.Context;
 import haxe.macro.Expr;
 using haxe.macro.TypeTools;
 import restx.core.macros.Macros.*;
+using thx.core.Iterables;
 
 class AutoRegisterRoute {
   public static function register(router : Expr, instance : Expr) : Expr {
@@ -14,11 +15,9 @@ class AutoRegisterRoute {
     // iterate on all the fields and filter the functions that have @:path
     var fields = filterControllerMethods(type.fields.get());
 
-    var methods = ["get", "post", "head", "options", "put", "delete", "trace", "connect"];
-
     var definitions = fields.map(function(field) {
         var metas   = field.meta.get(),
-            meta    = findMetaFromNames(metas, methods),
+            meta    = findMetaFromNames(metas, restx.Methods.list),
             method  = meta.name.substring(1),
             path    = getMetaAsString(meta, 0),
             args    = getArguments(field);
@@ -114,7 +113,8 @@ class AutoRegisterRoute {
     var results = [];
     for(field in fields) {
       for(meta in field.meta.get()) {
-        if (["get", "post", "head", "options", "put", "delete", "trace", "connect"].indexOf(meta.name.substring(1)) < 0) {
+        var find = meta.name.substring(1);
+        if (!restx.Methods.list.any(function (method) return method == find)) {
           continue;
         }
         results.push(field);

--- a/src/restx/core/macros/AutoRegisterRoute.hx
+++ b/src/restx/core/macros/AutoRegisterRoute.hx
@@ -15,14 +15,17 @@ class AutoRegisterRoute {
     var fields = filterControllerMethods(type.fields.get());
 
     var definitions = fields.map(function(field) {
-        var metas   = field.meta.get(),
-            meta    = findMeta(metas, ":path"),
+        var methods = [":get", ":post", ":put", ":delete"],
+            metas   = field.meta.get(),
+            meta    = findMetaFromNames(metas, methods),
+            method  = meta.name.substring(1),
             path    = getMetaAsString(meta, 0),
             args    = getArguments(field);
         return {
           name : field.name,
           path : path,
-          arguments : args
+          arguments : args,
+          method: method
         };
       });
 
@@ -56,7 +59,7 @@ class AutoRegisterRoute {
                   Context.currentPos()));
 
         var path = definition.path,
-            method = "get"; // TODO
+            method = definition.method;
         exprs.push(macro router.registerMethod($v{path}, $v{method}, cast process));
 
         var params = definition.arguments.map(function(arg) : Field return {
@@ -110,7 +113,7 @@ class AutoRegisterRoute {
     var results = [];
     for(field in fields) {
       for(meta in field.meta.get()) {
-        if(meta.name != ":path")
+        if(meta.name != ":get")
           continue;
         results.push(field);
         break;

--- a/src/restx/core/macros/AutoRegisterRoute.hx
+++ b/src/restx/core/macros/AutoRegisterRoute.hx
@@ -14,9 +14,10 @@ class AutoRegisterRoute {
     // iterate on all the fields and filter the functions that have @:path
     var fields = filterControllerMethods(type.fields.get());
 
+    var methods = ["get", "post", "head", "options", "put", "delete", "trace", "connect"];
+
     var definitions = fields.map(function(field) {
-        var methods = [":get", ":post", ":put", ":delete"],
-            metas   = field.meta.get(),
+        var metas   = field.meta.get(),
             meta    = findMetaFromNames(metas, methods),
             method  = meta.name.substring(1),
             path    = getMetaAsString(meta, 0),
@@ -113,8 +114,9 @@ class AutoRegisterRoute {
     var results = [];
     for(field in fields) {
       for(meta in field.meta.get()) {
-        if(meta.name != ":get")
+        if (["get", "post", "head", "options", "put", "delete", "trace", "connect"].indexOf(meta.name.substring(1)) < 0) {
           continue;
+        }
         results.push(field);
         break;
       }

--- a/src/restx/core/macros/AutoRegisterRoute.hx
+++ b/src/restx/core/macros/AutoRegisterRoute.hx
@@ -24,7 +24,7 @@ class AutoRegisterRoute {
         return {
           name : field.name,
           path : path,
-          arguments : args,
+          args : args,
           method: method
         };
       });
@@ -39,12 +39,12 @@ class AutoRegisterRoute {
         // create a class type for each controller function
         var processName = [type.name, definition.name, "RouteProcess"].join("_"),
             fullName = type.pack.concat([processName]).join("."),
-            fields = createProcessFields(definition.name, definition.arguments),
+            fields = createProcessFields(definition.name, definition.args),
             exprs  = [];
 
         exprs.push(Context.parse('var filters = new restx.core.ArgumentsFilter()',
                   Context.currentPos()));
-        var args = definition.arguments.map(function(arg) {
+        var args = definition.args.map(function(arg) {
             var sources = arg.sources.map(function(s) return '"$s"').join(", ");
             return '{
               name     : "${arg.name}",
@@ -62,7 +62,7 @@ class AutoRegisterRoute {
             method = definition.method;
         exprs.push(macro router.registerMethod($v{path}, $v{method}, cast process));
 
-        var params = definition.arguments.map(function(arg) : Field return {
+        var params = definition.args.map(function(arg) : Field return {
               pos : Context.currentPos(),
               name : arg.name,
               kind : FVar(Context.follow(Context.getType(arg.type)).toComplexType())
@@ -125,10 +125,10 @@ class AutoRegisterRoute {
   }
 
   static function createProcessFields(name : String, args : Array<ArgumentRequirement>) {
-    var arguments = args.map(function(arg) {
-            return 'arguments.${arg.name}';
+    var args = args.map(function(arg) {
+            return 'args.${arg.name}';
           }).join(", "),
-        execute = 'instance.$name($arguments)';
+        execute = 'instance.$name($args)';
     return [createFunctionField("execute", [AOverride], Context.parse(execute, Context.currentPos()))];
   }
 

--- a/src/restx/core/macros/BuildIRoute.hx
+++ b/src/restx/core/macros/BuildIRoute.hx
@@ -44,8 +44,9 @@ class BuildIRoute {
 
   static function makeControllerFunctionsPublic(fields : Array<Field>) {
     for(field in fields) {
-      if(hasMeta(field.meta, ":get"))
-        makeFieldPublic(field);
+      for (method in ["get", "post", "head", "options", "put", "delete", "trace", "connect"])
+        if(hasMeta(field.meta, ":" + method))
+          makeFieldPublic(field);
     }
   }
 }

--- a/src/restx/core/macros/BuildIRoute.hx
+++ b/src/restx/core/macros/BuildIRoute.hx
@@ -44,7 +44,7 @@ class BuildIRoute {
 
   static function makeControllerFunctionsPublic(fields : Array<Field>) {
     for(field in fields) {
-      for (method in ["get", "post", "head", "options", "put", "delete", "trace", "connect"])
+      for (method in restx.Methods.list)
         if(hasMeta(field.meta, ":" + method))
           makeFieldPublic(field);
     }

--- a/src/restx/core/macros/BuildIRoute.hx
+++ b/src/restx/core/macros/BuildIRoute.hx
@@ -44,7 +44,7 @@ class BuildIRoute {
 
   static function makeControllerFunctionsPublic(fields : Array<Field>) {
     for(field in fields) {
-      if(hasMeta(field.meta, ":path"))
+      if(hasMeta(field.meta, ":get"))
         makeFieldPublic(field);
     }
   }

--- a/src/restx/core/macros/Macros.hx
+++ b/src/restx/core/macros/Macros.hx
@@ -65,6 +65,16 @@ class Macros {
     return hasFieldInHirearchy(superClass.t.get(), name);
   }
 
+  public static function findMetaFromNames(meta : Array<MetadataEntry>, whitelistedNames : Array<String>) {
+    for (name in whitelistedNames) {
+      var meta = findMeta(meta, name);
+      if (meta != null) {
+        return meta;
+      }
+    }
+    return null;
+  }
+
   public static function findMeta(meta : Array<MetadataEntry>, name : String) {
     if(null == meta)
       return null;
@@ -78,7 +88,7 @@ class Macros {
     return findMeta(meta, name) != null;
 
   public static function getMetaAsString(meta : MetadataEntry, pos : Int) {
-    if(null == meta.params[pos])
+    if(null == meta || null == meta.params[pos])
       return null;
     return switch meta.params[pos].expr {
       case EConst(CString(s)): s;

--- a/src/restx/core/macros/Macros.hx
+++ b/src/restx/core/macros/Macros.hx
@@ -65,7 +65,7 @@ class Macros {
     return hasFieldInHirearchy(superClass.t.get(), name);
   }
 
-  public static function findMetaFromNames(meta : Array<MetadataEntry>, whitelistedNames : Array<String>) {
+  public static function findMetaFromNames(meta : Array<MetadataEntry>, whitelistedNames : Iterable<String>) {
     for (name in whitelistedNames) {
       var meta = findMeta(meta, ":" + name);
       if (meta != null) {

--- a/src/restx/core/macros/Macros.hx
+++ b/src/restx/core/macros/Macros.hx
@@ -67,7 +67,7 @@ class Macros {
 
   public static function findMetaFromNames(meta : Array<MetadataEntry>, whitelistedNames : Array<String>) {
     for (name in whitelistedNames) {
-      var meta = findMeta(meta, name);
+      var meta = findMeta(meta, ":" + name);
       if (meta != null) {
         return meta;
       }

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -1,4 +1,3 @@
-import js.node.http.Method;
 import utest.Assert;
 import utest.ui.Report;
 import utest.Runner;

--- a/test/TestCalls.hx
+++ b/test/TestCalls.hx
@@ -5,8 +5,9 @@ import restx.Router;
 import restx.core.Source;
 import restx.core.ArgumentProcessor;
 import js.node.Http;
+import js.node.http.*;
 import js.node.http.Method;
-import js.node.http.IncomingMessage;
+import js.node.Querystring;
 
 class TestCalls {
   var port : Int;
@@ -68,14 +69,14 @@ class TestCalls {
       Assert.equals('DONE', msg);
     });
 
-    request("/auto/", Post, function(msg) {
+    request("/auto/", Post, {foo: 'bar'}, function(msg : String) {
       Assert.equals('POSTED', msg);
     });
   }
 
-  function request(path : String, method : String, callback : String -> Void) {
+  function request(path : String, method : Method, ?payload : {}, callback : String -> Void) {
     var done = Assert.createAsync(2000);
-    Http.request({
+    var r = Http.request({
         host : "localhost",
         port : port,
         method : method,
@@ -89,6 +90,14 @@ class TestCalls {
           callback(data);
           done();
         });
-      }).end();
+      });
+
+    if (null != payload) {
+      var b = Querystring.stringify(payload);
+      r.setHeader('Content-Type', 'application/x-www-form-urlencoded');
+      r.setHeader('Content-Length', '${b.length}');
+      r.write(b);
+    }
+    r.end();
   }
 }

--- a/test/TestCalls.hx
+++ b/test/TestCalls.hx
@@ -67,6 +67,10 @@ class TestCalls {
     request("/auto/", Get, function(msg) {
       Assert.equals('DONE', msg);
     });
+
+    request("/auto/", Post, function(msg) {
+      Assert.equals('POSTED', msg);
+    });
   }
 
   function request(path : String, method : String, callback : String -> Void) {

--- a/test/routes/Auto.hx
+++ b/test/routes/Auto.hx
@@ -8,6 +8,12 @@ class Auto implements restx.IRoute {
     response.send("DONE");
   }
 
+  @:post("/auto/")
+  function noParamPost() {
+    trace("BODY is " + request.body);
+    response.send("POSTED");
+  }
+
   @:get("/auto/:name/:age")
   function withParams(name : String, age : Int) {
     Assert.is(name, String);

--- a/test/routes/Auto.hx
+++ b/test/routes/Auto.hx
@@ -3,12 +3,12 @@ package routes;
 import utest.Assert;
 
 class Auto implements restx.IRoute {
-  @:path("/auto/")
+  @:get("/auto/")
   function noParams() {
     response.send("DONE");
   }
 
-  @:path("/auto/:name/:age")
+  @:get("/auto/:name/:age")
   function withParams(name : String, age : Int) {
     Assert.is(name, String);
     Assert.is(age, Int);


### PR DESCRIPTION
Instead of `@:path("/some/path")` to handle routes, you can (must) now use `@:<http-method>` where <http-method> is one of:
- get
- post
- head
- options
- put
- delete
- trace
- connect

This PR doesn't handle the following:
- `@:all`, where Express allows you to create a single function to handle any incoming traffic for a path. #17 
- Creating several `@:<method>("/path")` metadata for the same function. #18
