### PR TITLE
added feature described in issue #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ WARNING: this is an experimental project and might be dropped at any time.
 
 ### Setup
 
-Create a new instance of a restx.App, which listens for http traffic on a port of your choice:
+Create a new instance of a `restx.App`, which listens for http traffic on a port of your choice:
 
 ```haxe
 import restx.App;
@@ -34,6 +34,10 @@ class RouteHandler implements restx.IRoute {
 ```
 
 ### Routes
+
+TODO
+
+By default arguments are taken from `params` (the route path) but with the `@:args()` meta you can take the arguments from: `query`, `body` or `params`. @:args can also take an array of sources when multiple sources are desired. Sources can be specified as either identifiers (no quotes) or strings.
 
 #### Basic HTTP Methods
 

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -11,6 +11,7 @@ class TestAll {
     // run REST tests
     runner.addCase(new TestManual());
     runner.addCase(new TestAuto());
+    runner.addCase(new TestParam());
 
     // report
     Report.create(runner);

--- a/test/TestParam.hx
+++ b/test/TestParam.hx
@@ -1,0 +1,21 @@
+import utest.Assert;
+import routes.*;
+import js.node.http.Method;
+
+class TestParam extends TestCalls {
+  public function testFromQS() {
+    router.register(new Param());
+
+    request("/list/", Get, function(msg) {
+      Assert.equals('page: 1', msg);
+    });
+
+    request("/list/?page=2", Get, function(msg) {
+      Assert.equals('page: 2', msg);
+    });
+
+    request("/list2/some/?page=2", Get, function(msg) {
+      Assert.equals('some: 2', msg);
+    });
+  }
+}

--- a/test/routes/Param.hx
+++ b/test/routes/Param.hx
@@ -1,0 +1,17 @@
+package routes;
+
+import utest.Assert;
+
+class Param implements restx.IRoute {
+  @:get("/list/")
+  @:args(query)
+  function fromQS(page : Int = 1) {
+    response.send('page: $page');
+  }
+
+  @:get("/list2/:name")
+  @:args([query, params])
+  function fromQSAndParam(name : String, page : Int = 1) {
+    response.send('$name: $page');
+  }
+}


### PR DESCRIPTION
Implemented differently from what planned. By default arguments are taken from `params` (the route path) but with the `@:args()` meta you can take the arguments from: `query`, `body` or `params`. @:args can also take an array of sources when multiple sources are desired. Sources can be specified as either identifiers (no quotes) or strings.
