### PR TITLE
Custom filters

### DIFF
--- a/src/abe/IFilterArgument.hx
+++ b/src/abe/IFilterArgument.hx
@@ -1,4 +1,4 @@
-package abe.core;
+package abe;
 
 import thx.promise.Promise;
 

--- a/src/abe/core/ArgumentProcessor.hx
+++ b/src/abe/core/ArgumentProcessor.hx
@@ -38,7 +38,12 @@ class ArgumentProcessor<TArgs : {}> {
   static function getValue(name : String, source : { params : {}, query : {}, body : {} }, sources : Array<Source>) {
     var o, value;
     for(sourceName in sources) {
-      o = Reflect.field(source, sourceName);
+      var o = switch sourceName {
+        case Request: source;
+        case Body: source.body;
+        case Params: source.params;
+        case Query: source.query;
+      }
       if(null == o) continue;
       value = Reflect.field(o, name);
       if(null != value)

--- a/src/abe/core/IFilterArgument.hx
+++ b/src/abe/core/IFilterArgument.hx
@@ -5,5 +5,5 @@ import thx.promise.Promise;
 interface IFilterArgument<T> {
   public var type : String;
 
-  function filter(value : String) : Promise<T>;
+  function filter(value : Dynamic) : Promise<T>;
 }

--- a/src/abe/core/Source.hx
+++ b/src/abe/core/Source.hx
@@ -5,4 +5,5 @@ abstract Source(String) from String to String {
   var Params = "params";
   var Query = "query";
   var Body = "body";
+  var Request = "request";
 }

--- a/src/abe/core/Source.hx
+++ b/src/abe/core/Source.hx
@@ -1,6 +1,7 @@
 package abe.core;
 
-@:enum abstract Source(String) from String to String {
+@:enum
+abstract Source(String) from String to String {
   var Params = "params";
   var Query = "query";
   var Body = "body";

--- a/src/abe/core/filters/BoolFilter.hx
+++ b/src/abe/core/filters/BoolFilter.hx
@@ -8,7 +8,15 @@ class BoolFilter implements IFilterArgument<Bool> {
   public function new(){}
 
   public var type = "Bool";
-  public function filter(value : String) : Promise<Bool> {
+  public function filter(value : Dynamic) : Promise<Bool> {
+    if(Std.is(value, Bool))
+      return Promise.value(value);
+    if(Std.is(value, Int))
+      return Promise.value(value != 0);
+
+    if(!Std.is(value, String))
+      return Promise.error(new Error('"$value" is not a type that can be converted to a Bool'));
+
     if(Bools.canParse(value))
       return Promise.value(Bools.parse(value));
     else

--- a/src/abe/core/filters/DateFilter.hx
+++ b/src/abe/core/filters/DateFilter.hx
@@ -9,7 +9,13 @@ class DateFilter implements IFilterArgument<Date> {
   public function new(){}
 
   public var type = "Date";
-  public function filter(value : String) : Promise<Date> {
+  public function filter(value : Dynamic) : Promise<Date> {
+    if(Std.is(value, Float))
+      return Promise.value(Date.fromTime(value));
+
+    if(!Std.is(value, String))
+      return Promise.error(new Error('"$value" is not a type that can be converted to a Date'));
+
     if(TIME_PATTERN.match(value))
       return Promise.value(Date.fromTime(Floats.parse(value)));
     try {

--- a/src/abe/core/filters/FloatFilter.hx
+++ b/src/abe/core/filters/FloatFilter.hx
@@ -8,7 +8,16 @@ class FloatFilter implements IFilterArgument<Float> {
   public function new(){}
 
   public var type = "Float";
-  public function filter(value : String) : Promise<Float> {
+  public function filter(value : Dynamic) : Promise<Float> {
+    if(Std.is(value, Float))
+      return Promise.value(value);
+
+    if(Std.is(value, Bool))
+      return Promise.value(true ? 1.0 : 0.0);
+
+    if(!Std.is(value, String))
+      return Promise.error(new Error('"$value" is not a type that can be converted to a Float'));
+
     if(Floats.canParse(value))
       return Promise.value(Floats.parse(value));
     else

--- a/src/abe/core/filters/IntFilter.hx
+++ b/src/abe/core/filters/IntFilter.hx
@@ -8,7 +8,16 @@ class IntFilter implements IFilterArgument<Int> {
   public function new(){}
 
   public var type = "Int";
-  public function filter(value : String) : Promise<Int> {
+  public function filter(value : Dynamic) : Promise<Int> {
+    if(Std.is(value, Int))
+      return Promise.value(value);
+
+    if(Std.is(value, Bool))
+      return Promise.value(true ? 1 : 0);
+
+    if(!Std.is(value, String))
+      return Promise.error(new Error('"$value" is not a type that can be converted to a Int'));
+
     if(Ints.canParse(value))
       return Promise.value(Ints.parse(value));
     else

--- a/src/abe/core/filters/StringFilter.hx
+++ b/src/abe/core/filters/StringFilter.hx
@@ -6,6 +6,6 @@ class StringFilter implements IFilterArgument<String> {
   public function new(){}
 
   public var type = "String";
-  public function filter(value : String) : Promise<String>
-    return Promise.value(value);
+  public function filter(value : Dynamic) : Promise<String>
+    return Promise.value('$value');
 }

--- a/src/abe/core/macros/AutoRegisterRoute.hx
+++ b/src/abe/core/macros/AutoRegisterRoute.hx
@@ -201,8 +201,8 @@ class AutoRegisterRoute {
       case _:
         Context.error("parameter for query should be an identifier or an array of identifiers", field.pos);
     }).flatten();
-    sources.map(function(source) switch source {
-        case "query", "params", "body":
+    sources.map(function(source : Source) switch source {
+        case Query, Params, Body, Request:
         case _: Context.error('"$source" is not a valid @:source()', field.pos);
       });
     return sources;

--- a/src/abe/core/macros/AutoRegisterRoute.hx
+++ b/src/abe/core/macros/AutoRegisterRoute.hx
@@ -42,10 +42,6 @@ class AutoRegisterRoute {
         });
       }).flatten();
 
-    if(definitions.length == 0) {
-      Context.error("There are no controller methods defined in this class", Context.currentPos());
-    }
-
     var exprs = [macro var router = parent.mount($v{prefix})];
 
     exprs = exprs.concat(uses.map(


### PR DESCRIPTION
At class level and "handler" level it is now possible to specify an instance for a custom filter. The instance must implement `abe.IFilterArgument`.

Also added `Request` as a source for arguments since middlewares have the habit to append data directly there.
