### PR TITLE
values sources can now be paired to specific argument names

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Franco Ponticelli <franco.ponticelli@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.12.2",
-    "qs": "^2.4.0"
+    "body-parser": "^1.13.1",
+    "express": "^4.12.2"
   }
 }

--- a/src/abe/core/RouteProcess.hx
+++ b/src/abe/core/RouteProcess.hx
@@ -25,7 +25,6 @@ class RouteProcess<TRoute : IRoute, TArgs : {}> {
           next.call();
       }
     });
-
   }
 
   function execute(req : Request, res : Response, next : Next)

--- a/src/abe/core/filters/ObjectFilter.hx
+++ b/src/abe/core/filters/ObjectFilter.hx
@@ -21,7 +21,6 @@ class ObjectFilter implements IFilterArgument<{}> {
         return Promise.value(v);
       return Promise.error(new Error('"$value" cannot be transformed to an Object value'));
     }
-
     return Promise.error(new Error('"$value" is not an Object value'));
   }
 }

--- a/src/abe/core/filters/ObjectFilter.hx
+++ b/src/abe/core/filters/ObjectFilter.hx
@@ -16,7 +16,7 @@ class ObjectFilter implements IFilterArgument<{}> {
       var v = try Json.parse(value) catch(e : Dynamic) null;
       if(null != v)
         return Promise.value(v);
-      v = try npm.QS.parse(value);
+      v = try thx.QueryString.parse(value).object() catch(e : Dynamic) null;
       if(null != v)
         return Promise.value(v);
       return Promise.error(new Error('"$value" cannot be transformed to an Object value'));

--- a/src/abe/core/macros/AutoRegisterRoute.hx
+++ b/src/abe/core/macros/AutoRegisterRoute.hx
@@ -293,28 +293,37 @@ class AutoRegisterRoute {
       case TFun(args, _):
         args.slice(0, args.length - 3).map(function(arg) {
           return {
-              name : arg.name,
-              optional : arg.opt,
-              type : arg.t.toString(),
-              sources : getSources(field)
+            name : arg.name,
+            optional : arg.opt,
+            type : arg.t.toString(),
+            sources : getSources(field, arg.name)
           };
         });
       case _: [];
     };
   }
 
-  static function getSources(field : ClassField) {
+  static function getSources(field : ClassField, argName : String) {
     var meta = findMeta(field.meta.get(), ":args");
     if(null == meta)
       return ["params"];
     var sources = meta.params.map(function(p) return switch p.expr {
-      case EConst(CIdent(id)), EConst(CString(id)):
+      case EConst(CIdent(id)), EConst(CString(id)),
+           ECall({ expr : EConst(CIdent(id)), pos : _ }, []):
         [id.toLowerCase()];
       case EArrayDecl(arr): arr.map(function(p) return switch p.expr {
           case EConst(CIdent(id)): id.toLowerCase();
           case _: Context.error("parameter for query should be an identifier or an array of identifiers", field.pos);
         });
-      case _:
+      case ECall({ expr : EConst(CIdent(source)), pos : _ }, args):
+        args.filter(function(arg) {
+          return switch arg.expr {
+            case EConst(CIdent(argId)) if(argId == argName): true;
+            case _: false;
+          };
+        }).map(function(_) return source.toLowerCase());
+      case other:
+        trace(other);
         Context.error("parameter for query should be an identifier or an array of identifiers", field.pos);
     }).flatten();
     sources.map(function(source : Source) switch source {

--- a/src/abe/core/macros/AutoRegisterRoute.hx
+++ b/src/abe/core/macros/AutoRegisterRoute.hx
@@ -33,7 +33,6 @@ class AutoRegisterRoute {
 
         return metas.map(function(meta) {
           var args = getArguments(field);
-          args = args.slice(0, args.length - 3);
           return {
             name: field.name,
             path: getMetaAsString(meta, 0),
@@ -292,7 +291,7 @@ class AutoRegisterRoute {
   static function getArguments(field : ClassField) : Array<ArgumentRequirement> {
     return switch Context.follow(field.type) {
       case TFun(args, _):
-        args.map(function(arg) {
+        args.slice(0, args.length - 3).map(function(arg) {
           return {
               name : arg.name,
               optional : arg.opt,

--- a/test/TestParam.hx
+++ b/test/TestParam.hx
@@ -16,6 +16,27 @@ class TestParam extends TestCalls {
     get("/list2/some/?page=2", function(msg, _) {
       Assert.equals('some: 2', msg);
     });
+
+    // restrict param source
+    get("/get/123?partial=true&id=456", function(msg, res) {
+      if(res.statusCode != 200) {
+        Assert.fail(msg);
+      } else {
+        Assert.same({ partial : true, id : 123 }, haxe.Json.parse(msg));
+      }
+    });
+
+    post("/post/?a=A&b=B&c=C", {a:"a",b:"b",c:"c"}, function(msg : String, res) {
+      if(res.statusCode != 200) {
+        Assert.fail(msg);
+      } else {
+        Assert.same({
+          a : "A",
+          b : "B",
+          c : "c"
+        }, haxe.Json.parse(msg));
+      }
+    });
   }
 }
 
@@ -36,5 +57,21 @@ class Param implements abe.IRoute {
   @:args(body)
   function fromBodyArray(name : String, pages : Array<String>) {
     response.send('$name: $pages');
+  }
+
+  @:get("/get/:id")
+  @:args(query(partial), params(id))
+  function restrict(id : Int, partial : Bool) {
+    response.send({
+      id : id,
+      partial : partial
+    });
+  }
+
+  @:post("/post/")
+  @:use(mw.BodyParser.urlencoded({ extended : false }))
+  @:args(query(a,b), body(c))
+  function restrictQuery(a : String, b : String, c : String) {
+    response.send({ a : a, b : b, c : c });
   }
 }


### PR DESCRIPTION
Example:

``` haxe
  @:post("/post/")
  @:args(query(a,b), body(c))
  function restrictQuery(a : String, b : String, c : String) {
    // ...
  }
```
