### PR TITLE
Error handling helpers

### DIFF
--- a/src/abe/error/BadGatewayError.hx
+++ b/src/abe/error/BadGatewayError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class BadGatewayError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Bad Gateway";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 502, pos);
+  }
+}

--- a/src/abe/error/BadRequestError.hx
+++ b/src/abe/error/BadRequestError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class BadRequestError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Bad Request";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 400, pos);
+  }
+}

--- a/src/abe/error/BaseHttpError.hx
+++ b/src/abe/error/BaseHttpError.hx
@@ -1,8 +1,9 @@
 package abe.error;
 
-class BaseHttpError extends express.Error {
-  public function new(msg : String, statusCode : Int) {
-    super(msg);
-    this.status = statusCode;
+class BaseHttpError extends thx.Error {
+  public var status(default, null) : Int;
+  public function new(msg : String, status : Int, ?pos : haxe.PosInfos) {
+    super(msg, pos);
+    this.status = status;
   }
 }

--- a/src/abe/error/BaseHttpError.hx
+++ b/src/abe/error/BaseHttpError.hx
@@ -1,0 +1,9 @@
+package abe.error;
+
+class BaseHttpError extends thx.Error {
+  public var statusCode : Int;
+  public function new(msg : String, statusCode : Int) {
+    super(msg);
+    this.statusCode = statusCode;
+  }
+}

--- a/src/abe/error/BaseHttpError.hx
+++ b/src/abe/error/BaseHttpError.hx
@@ -1,9 +1,8 @@
 package abe.error;
 
-class BaseHttpError extends thx.Error {
-  public var statusCode : Int;
+class BaseHttpError extends express.Error {
   public function new(msg : String, statusCode : Int) {
     super(msg);
-    this.statusCode = statusCode;
+    this.status = statusCode;
   }
 }

--- a/src/abe/error/ForbiddenError.hx
+++ b/src/abe/error/ForbiddenError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class ForbiddenError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Forbidden";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 403, pos);
+  }
+}

--- a/src/abe/error/GatewayTimeoutError.hx
+++ b/src/abe/error/GatewayTimeoutError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class GatewayTimeoutError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Gateway Timeout";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 504, pos);
+  }
+}

--- a/src/abe/error/InternalServerError.hx
+++ b/src/abe/error/InternalServerError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class InternalServerError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Internal Server Error";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 500, pos);
+  }
+}

--- a/src/abe/error/NotFoundError.hx
+++ b/src/abe/error/NotFoundError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class NotFoundError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Not Found";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 404, pos);
+  }
+}

--- a/src/abe/error/NotImplementedError.hx
+++ b/src/abe/error/NotImplementedError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class NotImplementedError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Not Implemented";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 501, pos);
+  }
+}

--- a/src/abe/error/ServiceUnavailableError.hx
+++ b/src/abe/error/ServiceUnavailableError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class ServiceUnavailableError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Service Unavailable";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 503, pos);
+  }
+}

--- a/src/abe/error/UnauthorizedError.hx
+++ b/src/abe/error/UnauthorizedError.hx
@@ -1,0 +1,8 @@
+package abe.error;
+
+class UnauthorizedError extends BaseHttpError {
+  static var DEFAULT_MESSAGE = "Unauthorized";
+  public function new(?msg : String, ?pos : haxe.PosInfos) {
+    super(msg == null ? DEFAULT_MESSAGE : msg, 401, pos);
+  }
+}

--- a/src/abe/mw/ErrorHandler.hx
+++ b/src/abe/mw/ErrorHandler.hx
@@ -1,0 +1,29 @@
+package abe.mw;
+
+import abe.error.BaseHttpError;
+import js.Error;
+using thx.Strings;
+
+class ErrorHandler {
+  public static var handle(default, null) : ErrorMiddleware;
+
+  handle = function(err : Error, request : Request, response : Response, next : Next) {
+    var httpError : BaseHttpError = Std.is(err, BaseHttpError) ? cast err : null;
+
+    // if we have an error we can understand, just do the right thing
+    if (httpError != null) sendError(httpError.statusCode, httpError, response);
+
+    // otherwise, check the name and message for common terms
+    else if (err.name.toLowerCase().startsWith("unauthorized")) sendError(401, err, response);
+    else if (err.message.toLowerCase().startsWith("cannot validate")) sendError(400, err, response);
+
+    // and finally, fall back to a good old fashioned 500 error
+    else sendError(500, err, response);
+  }
+
+  static function sendError(status, err : Error, response : Response) {
+    // TODO: configure this with a Bool `debug` flag and conditionally send/log err.stack
+    response.status(status);
+    response.send(err.message);
+  }
+}

--- a/src/abe/mw/ErrorHandler.hx
+++ b/src/abe/mw/ErrorHandler.hx
@@ -1,13 +1,15 @@
 package abe.mw;
 
 import abe.error.BaseHttpError;
+import express.Middleware;
+import express.Next;
+import express.Request;
+import express.Response;
 import js.Error;
 using thx.Strings;
 
 class ErrorHandler {
-  public static var handle(default, null) : ErrorMiddleware;
-
-  handle = function(err : Error, request : Request, response : Response, next : Next) {
+  public static var handle(default, null) : ErrorMiddleware = function(err : Error, request : Request, response : Response, next : Next) {
     var httpError : BaseHttpError = Std.is(err, BaseHttpError) ? cast err : null;
 
     // if we have an error we can understand, just do the right thing

--- a/src/abe/mw/ErrorHandler.hx
+++ b/src/abe/mw/ErrorHandler.hx
@@ -13,7 +13,7 @@ class ErrorHandler {
     var httpError : BaseHttpError = Std.is(err, BaseHttpError) ? cast err : null;
 
     // if we have an error we can understand, just do the right thing
-    if (httpError != null) sendError(httpError.statusCode, httpError, response);
+    if (httpError != null) sendError(httpError.status, httpError, response);
 
     // otherwise, check the name and message for common terms
     else if (err.name.toLowerCase().startsWith("unauthorized")) sendError(401, err, response);

--- a/src/abe/mw/ErrorHandler.hx
+++ b/src/abe/mw/ErrorHandler.hx
@@ -9,23 +9,38 @@ import js.Error;
 using thx.Strings;
 
 class ErrorHandler {
-  public static var handle(default, null) : ErrorMiddleware = function(err : Error, request : Request, response : Response, next : Next) {
-    var httpError : BaseHttpError = Std.is(err, BaseHttpError) ? cast err : null;
+  public static function handle(?debug = false) : ErrorMiddleware {
+    return function(err : Error, request : Request, response : Response, next : Next) {
+      var httpError : BaseHttpError = Std.is(err, BaseHttpError) ? cast err : null;
 
-    // if we have an error we can understand, just do the right thing
-    if (httpError != null) sendError(httpError.status, httpError, response);
+      // if we have an error we can understand, just do the right thing
+      if (httpError != null) sendError(httpError.status, httpError, response, debug);
 
-    // otherwise, check the name and message for common terms
-    else if (err.name.toLowerCase().startsWith("unauthorized")) sendError(401, err, response);
-    else if (err.message.toLowerCase().startsWith("cannot validate")) sendError(400, err, response);
+      // otherwise, check the name and message for common terms
+      else if (err.name.toLowerCase().startsWith("unauthorized")) sendError(401, err, response, debug);
+      else if (err.message.toLowerCase().startsWith("cannot validate")) sendError(400, err, response, debug);
 
-    // and finally, fall back to a good old fashioned 500 error
-    else sendError(500, err, response);
+      // and finally, fall back to a good old fashioned 500 error
+      else sendError(500, err, response, debug);
+    };
   }
 
-  static function sendError(status, err : Error, response : Response) {
-    // TODO: configure this with a Bool `debug` flag and conditionally send/log err.stack
+  static function sendError(status, err : Error, response : Response, debug : Bool) {
     response.status(status);
+
+    // conditionally send/log err.stack
+    if (debug) {
+      trace('ABE SENDING ERROR STATUS: $status');
+      if (err.stack != null) {
+        trace(err.stack);
+      }
+
+      // send the full error object to the client
+      response.send(err);
+      return;
+    }
+
+    // no debug, so just send the message
     response.send(err.message);
   }
 }

--- a/test/TestAll.hx
+++ b/test/TestAll.hx
@@ -20,6 +20,7 @@ class TestAll {
     runner.addCase(new TestValidate());
     runner.addCase(new TestIs());
     runner.addCase(new TestError());
+    runner.addCase(new TestErrorHandling());
 
     // report
     Report.create(runner);

--- a/test/TestErrorHandling.hx
+++ b/test/TestErrorHandling.hx
@@ -7,7 +7,12 @@ using thx.Strings;
 class TestErrorHandling extends TestCalls {
   public function testBasicHttpError() {
     app.router.register(new ErrorMaker());
-    app.router.error(abe.mw.ErrorHandler.handle);
+
+    var normalRouter = app.router.mount("/"),
+        debugRouter = app.router.mount("/debug");
+
+    normalRouter.error(abe.mw.ErrorHandler.handle());
+    debugRouter.error(abe.mw.ErrorHandler.handle(true));
 
     get("/badrequest", function (msg, res) {
       Assert.equals("Bad Request", msg);
@@ -64,6 +69,10 @@ class TestErrorHandling extends TestCalls {
     });
 
     get("/completely/missing", function (_, res) {
+      Assert.equals(404, res.statusCode);
+    });
+
+    get("/debug/badRequest", function (_, res) {
       Assert.equals(404, res.statusCode);
     });
   }

--- a/test/TestErrorHandling.hx
+++ b/test/TestErrorHandling.hx
@@ -8,6 +8,11 @@ class TestErrorHandling extends TestCalls {
     app.router.register(new ErrorMaker());
     app.router.error(abe.mw.ErrorHandler.handle);
 
+    get("/unauthorized", function (msg, res) {
+      Assert.equals("Must be logged in", msg);
+      Assert.equals(401, res.statusCode);
+    });
+
     get("/teapot/coffee", function (_, res) {
       Assert.equals(418, res.statusCode);
     });
@@ -15,8 +20,13 @@ class TestErrorHandling extends TestCalls {
 }
 
 class ErrorMaker implements abe.IRoute {
-  @:get("/teapot/coffee")
+  @:get("/unauthorized")
   function unauthorized() {
+    next.error(new UnauthorizedError("Must be logged in"));
+  }
+
+  @:get("/teapot/coffee")
+  function teapot() {
     next.error(new BaseHttpError("I'm a teapot", 418));
   }
 }

--- a/test/TestErrorHandling.hx
+++ b/test/TestErrorHandling.hx
@@ -6,11 +6,11 @@ using thx.Strings;
 
 class TestErrorHandling extends TestCalls {
   public function testBasicHttpError() {
-    app.router.register(new ErrorMaker());
-
     var normalRouter = app.router.mount("/"),
         debugRouter = app.router.mount("/debug");
 
+    normalRouter.register(new ErrorMaker());
+    debugRouter.register(new ErrorMaker());
     normalRouter.error(abe.mw.ErrorHandler.handle());
     debugRouter.error(abe.mw.ErrorHandler.handle(true));
 
@@ -72,8 +72,12 @@ class TestErrorHandling extends TestCalls {
       Assert.equals(404, res.statusCode);
     });
 
-    get("/debug/badRequest", function (_, res) {
-      Assert.equals(404, res.statusCode);
+    // in debug mode, the request returns an object instead of a string
+    get("/debug/badRequest", function (body, res) {
+      var parsed = haxe.Json.parse(body);
+      Assert.equals("Bad Request", parsed.message);
+      Assert.isTrue(parsed.stackItems.length > 0);
+      Assert.equals(400, res.statusCode);
     });
   }
 }

--- a/test/TestErrorHandling.hx
+++ b/test/TestErrorHandling.hx
@@ -1,0 +1,22 @@
+import utest.Assert;
+
+import abe.error.*;
+import express.*;
+
+class TestErrorHandling extends TestCalls {
+  public function testBasicHttpError() {
+    app.router.register(new ErrorMaker());
+    app.router.error(abe.mw.ErrorHandler.handle);
+
+    get("/teapot/coffee", function (_, res) {
+      Assert.equals(418, res.statusCode);
+    });
+  }
+}
+
+class ErrorMaker implements abe.IRoute {
+  @:get("/teapot/coffee")
+  function unauthorized() {
+    next.error(new BaseHttpError("I'm a teapot", 418));
+  }
+}

--- a/test/TestErrorHandling.hx
+++ b/test/TestErrorHandling.hx
@@ -2,27 +2,62 @@ import utest.Assert;
 
 import abe.error.*;
 import express.*;
+using thx.Strings;
 
 class TestErrorHandling extends TestCalls {
   public function testBasicHttpError() {
     app.router.register(new ErrorMaker());
     app.router.error(abe.mw.ErrorHandler.handle);
 
+    get("/badrequest", function (msg, res) {
+      Assert.equals("Bad Request", msg);
+      Assert.equals(400, res.statusCode);
+    });
+
     get("/unauthorized", function (msg, res) {
       Assert.equals("Must be logged in", msg);
       Assert.equals(401, res.statusCode);
     });
 
+    get("/forbidden", function (msg, res) {
+      Assert.equals("Forbidden", msg);
+      Assert.equals(403, res.statusCode);
+    });
+
+    get("/notfound", function (msg, res) {
+      Assert.isTrue(msg.startsWith("Resource"));
+      Assert.equals(404, res.statusCode);
+    });
+
     get("/teapot/coffee", function (_, res) {
       Assert.equals(418, res.statusCode);
+    });
+
+    get("/completely/missing", function (_, res) {
+      Assert.equals(404, res.statusCode);
     });
   }
 }
 
 class ErrorMaker implements abe.IRoute {
+  @:get("/badrequest")
+  function badRequest() {
+    next.error(new BadRequestError());
+  }
+
   @:get("/unauthorized")
   function unauthorized() {
     next.error(new UnauthorizedError("Must be logged in"));
+  }
+
+  @:get("/forbidden")
+  function forbidden() {
+    next.error(new ForbiddenError());
+  }
+
+  @:get("/notfound")
+  function notFound() {
+    next.error(new NotFoundError("Resource Not Found"));
   }
 
   @:get("/teapot/coffee")

--- a/test/TestErrorHandling.hx
+++ b/test/TestErrorHandling.hx
@@ -33,6 +33,36 @@ class TestErrorHandling extends TestCalls {
       Assert.equals(418, res.statusCode);
     });
 
+    get("/internalserver", function (msg, res) {
+      Assert.equals("Internal Server Error", msg);
+      Assert.equals(500, res.statusCode);
+    });
+
+    get("/notimplemented", function (msg, res) {
+      Assert.equals("Not Implemented", msg);
+      Assert.equals(501, res.statusCode);
+    });
+
+    get("/badgateway", function (msg, res) {
+      Assert.equals("Bad Gateway", msg);
+      Assert.equals(502, res.statusCode);
+    });
+
+    get("/serviceunavailable", function (msg, res) {
+      Assert.equals("Service Unavailable", msg);
+      Assert.equals(503, res.statusCode);
+    });
+
+    get("/gatewaytimeout", function (msg, res) {
+      Assert.equals("Gateway Timeout", msg);
+      Assert.equals(504, res.statusCode);
+    });
+
+    get("/uncaught", function (msg, res) {
+      Assert.equals("Something went wrong", msg);
+      Assert.equals(500, res.statusCode);
+    });
+
     get("/completely/missing", function (_, res) {
       Assert.equals(404, res.statusCode);
     });
@@ -63,5 +93,35 @@ class ErrorMaker implements abe.IRoute {
   @:get("/teapot/coffee")
   function teapot() {
     next.error(new BaseHttpError("I'm a teapot", 418));
+  }
+
+  @:get("/internalserver")
+  function internalServerError() {
+    next.error(new InternalServerError());
+  }
+
+  @:get("/notimplemented")
+  function notImplemented() {
+    next.error(new NotImplementedError());
+  }
+
+  @:get("/badgateway")
+  function badGateway() {
+    next.error(new BadGatewayError());
+  }
+
+  @:get("/gatewaytimeout")
+  function gatewayTimeout() {
+    next.error(new GatewayTimeoutError());
+  }
+
+  @:get("/serviceunavailable")
+  function serviceUnavailable() {
+    next.error(new ServiceUnavailableError());
+  }
+
+  @:get("/uncaught")
+  function uncaughtError() {
+    next.error(new thx.Error("Something went wrong"));
   }
 }


### PR DESCRIPTION
- Adds optional error handling middleware that can be easily attached to a router
- Adds specific error types that trigger appropriate status codes (`400`, `401`, `403`, `404`, `500`, `501`, `502`, `503`, `504`)
- Defaults to `500` status for unhandled errors that don't specify a code
- Includes a debug mode which sends the full stack trace to the client
